### PR TITLE
ci: split checks into jobs and add auto-tagging on main

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,22 +1,57 @@
-name: Rust
+name: CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  fmt:
+    name: Format
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-    - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+      - name: Check formatting
+        run: cargo fmt --check
+
+  clippy:
+    name: Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Install sqlite3 dev
+        run: sudo apt-get install -y libsqlite3-dev
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Install sqlite3 dev
+        run: sudo apt-get install -y libsqlite3-dev
+      - name: Run tests
+        run: cargo test --verbose
+
+  docker:
+    name: Docker build
+    runs-on: ubuntu-latest
+    needs: [fmt, clippy, test]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build .

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,39 @@
+name: Tag on merge
+
+on:
+  push:
+    branches: ["main"]
+
+jobs:
+  tag:
+    name: Create version tag
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from Cargo.toml
+        id: version
+        run: |
+          VERSION=$(grep '^version' Cargo.toml | head -1 | sed 's/.*"\(.*\)".*/\1/')
+          echo "version=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: tag_exists
+        run: |
+          if git rev-parse "${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and push tag
+        if: steps.tag_exists.outputs.exists == 'false'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.version }}"
+          git push origin "${{ steps.version.outputs.version }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# syntax=docker/dockerfile:1
+
+FROM rust:1-bookworm AS build
+WORKDIR /src
+
+# System deps for sqlx sqlite (non-bundled)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  libsqlite3-dev pkg-config \
+  && rm -rf /var/lib/apt/lists/*
+
+# Cache deps
+COPY Cargo.toml Cargo.lock ./
+RUN mkdir -p src && printf "fn main(){}" > src/main.rs
+RUN cargo build --release
+RUN rm -rf src
+
+# Build real binary
+COPY . .
+RUN cargo build --release
+
+# Small runtime image
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  ca-certificates libsqlite3-0 \
+  && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=build /src/target/release/pomo-tui /app/pomo-tui
+
+# HTTP API port
+EXPOSE 1881
+# TCP port
+EXPOSE 1880
+
+# Run server-only, bind to all interfaces
+ENTRYPOINT ["/app/pomo-tui","--server","--tcp-addr","0.0.0.0:1880","--http-addr","0.0.0.0:1881"]


### PR DESCRIPTION
- fmt, clippy, test run in parallel; docker build gates on all three
- Dockerfile: add libsqlite3-dev (build) and libsqlite3-0 (runtime)
- tag.yml: on push to main, create v{Cargo.toml version} tag if absent, which in turn triggers the existing release workflow